### PR TITLE
Added optional capability to use GPIO4 pin for PWM display dimming

### DIFF
--- a/EleksTubeHAX_pio/src/Backlights.h
+++ b/EleksTubeHAX_pio/src/Backlights.h
@@ -60,7 +60,7 @@ public:
   void adjustIntensity(int16_t adj);
   uint8_t getIntensity()                      { return config->intensity; }
 
-  bool dimming = false;
+  void setDimming(bool dim)                   { dimming = dim; pattern_needs_init = true; }
 
   // Helper methods
   uint32_t phaseToColor(uint16_t phase);
@@ -72,6 +72,7 @@ public:
   const uint8_t max_intensity = 8;  // 0 to 7
 
 private:
+  bool dimming = false;
   bool pattern_needs_init;
   bool off;
 

--- a/EleksTubeHAX_pio/src/GLOBAL_DEFINES.h
+++ b/EleksTubeHAX_pio/src/GLOBAL_DEFINES.h
@@ -78,9 +78,11 @@
 #ifndef HARDWARE_IPSTUBE_CLOCK
   #define ACTIVATEDISPLAYS      HIGH    // Activate is HIGH for the IPSTUBEs
   #define DEACTIVATEDISPLAYS    LOW     // Deactivate is LOW for the IPSTUBEs
+  #define CALCDIMVALUE(x)       (x)
 #else
   #define ACTIVATEDISPLAYS      LOW     // Activate is LOW for the Elekstube
   #define DEACTIVATEDISPLAYS    HIGH    // Deactivate is HIGH for the Elekstube
+  #define CALCDIMVALUE(x)       (255 - x)
 #endif
 
 
@@ -370,6 +372,7 @@
 
   // The H401 has the enable pin of the LCDs connectected to the VCC, so Always On.  
   #define TFT_ENABLE_PIN (GPIO_NUM_4) // pin 24 is GPIO4  
+  #define TFT_PWM_CHANNEL 0
 
   // configure library \TFT_eSPI\User_Setup.h
   // ST7789 135 x 240 display with no chip select line

--- a/EleksTubeHAX_pio/src/GLOBAL_DEFINES.h
+++ b/EleksTubeHAX_pio/src/GLOBAL_DEFINES.h
@@ -340,8 +340,8 @@
   #define BACKLIGHTS_PIN (GPIO_NUM_5) //pin 35 is GPIO5
 
   // ATTENTION: SOME IPSTUBE clocks has a LED stripe on the bottom of the clock! SOME NOT! Define the number of LEDs here!
-  #define NUM_BACKLIGHT_LEDS  (34) // 6 LEDs on the bottom of every LCD. For IPSTUBE clock with LED stripe: 28 LEDs in a stripe on the bottom of the clock = 34 LEDs in total.
-  //#define NUM_BACKLIGHT_LEDS  (6) // 6 LEDs on the bottom of every LCD. For IPSTUBE clock without LED stripe.
+  //#define NUM_BACKLIGHT_LEDS  (34) // 6 LEDs on the bottom of every LCD. For IPSTUBE clock with LED stripe: 28 LEDs in a stripe on the bottom of the clock = 34 LEDs in total.
+  #define NUM_BACKLIGHT_LEDS  (6) // 6 LEDs on the bottom of every LCD. For IPSTUBE clock without LED stripe.
 
   // Only one Button on IPSTUBE clocks!
   #define ONE_BUTTON_ONLY_MENU
@@ -358,8 +358,7 @@
     #define BUTTON_POWER_PIN (3)
     #define BUTTON_MODE_PIN (GPIO_NUM_0) // Only ONE Button on the back of the clock - pin 23 is GPIO0 = BOOT Button
   #endif
-  
-   
+     
   // 3-wire to DS1302 RTC
   #define DS1302_SCLK  (GPIO_NUM_22) // pin 39 is GPIO22
   #define DS1302_IO    (GPIO_NUM_19) // pin 38 is GPIO19
@@ -372,11 +371,44 @@
   // #define CSSR_LATCH_PIN (-1)
 
   // All IPSTUBEs has the LCDs pins VCC power (LED Anode) and VDD (Power Supply for Analog) connectected to the VCC (3.3V) and Ground to Ground (PCB), so the displays are Always-On!
-  // EXCEPT: The Q1 transistor is present! 
+  // EXCEPT: The Q1 transistor is present!
   // Then the GPIO4 pin is connected to the transistor and Ground of the LCDs is running through the transistor, so the LCDs can be turned on and off AND dimmed!
   #define TFT_ENABLE_PIN (GPIO_NUM_4) // pin 24 is GPIO4
   //if transistor is present and we want hardware dimming, we need to choose a PWM channel for this, can always be defines, even if not used
   #define TFT_PWM_CHANNEL 0
+
+  // Skip reinitialization
+  // This feature is only for IPSTUBE clocks by now!!! Can also be used on other clocks, but not tested yet!
+  // Always skip reinitialization for IPSTUBE clocks, because the displays are either always on (versions without Q1 transistor) 
+  // and a reinit just shows strange patterns on the displays and forces an unnecessary redraw of the clock digits.
+  // or seems to don't need a reinit (with Q1) -> this is an assumption, because the display came back on after a few hours without problems
+  // NOTE: If this causes wake up issues for you, disable it by commenting the following line out and go back to full reinit after display power off
+  #define TFT_SKIP_REINIT
+
+  // Hardware dimming!
+  // This feature is only supported by IPSTUBE clocks by now!!!
+  // DON'T USE IT WITH OTHER CLOCKS! IT MAY DAMAGE YOUR CLOCK!
+
+  // In case you have an IPSTUBE clock that does not support hardware dimming because of missing Q1 transistor:
+  // This will NOT damage your clock, but the dimming of the displays will be totally disabled! Also the LCD power switch will not work!
+  // If you notice, that the night time dimming or manual dimming does not work, you will have a clock without the Q1 transistor 
+  // and you can/should comment the following line out to get back to the software dimming!
+
+  // Comment the next line out, to DISABLE hardware dimming with GPIO4 pin (TFT_ENABLE_PIN) for a IPSTUBE clock  
+  #define DIM_WITH_ENABLE_PIN_PWM
+    
+  //NOTE: If NIGTHTIME_DIMMING is enabled: 
+  // For the main LCDs: The dimming will be set to the hard coded value TFT_DIMMED_INTENSITY in the given time period EVERY HOUR beginning at NIGHT_TIME
+  //    and will set back to the maximum brightness at DAY_TIME...Disable NIGHTTIME_DIMMING if you want to use the manual set dimming value all the time
+  // For the backlight dimming: The dimming will ALWAYS stay to the hard coded value BACKLIGHT_DIMMED_INTENSITY in the given night time period! 
+  //    The check for it is done and the value is apply every loop...Disable NIGHTTIME_DIMMING if you want to use the manual set dimming value all the time
+
+  // TODO: Store the dimming values and dimming times in the NVS partition to keep the last dimming value and not use the hard coded values
+  // make the times and values adjustable in the menu and/or via MQTT for both main and backlight dimming
+
+  // TODO: Save the values changed via MQTT/in HA in the NVS partition to keep the values after a reboot. Maybe define a "save command" in HA or trigger after 
+  // a few minutes of inactivity only if changed something or in the "free time" of the loop cycle...
+  // Save it every time receiving MQTT commands is a BAD idea, we know that already ;)
 
   // configure library \TFT_eSPI\User_Setup.h
   // ST7789 135 x 240 display with no chip select line

--- a/EleksTubeHAX_pio/src/GLOBAL_DEFINES.h
+++ b/EleksTubeHAX_pio/src/GLOBAL_DEFINES.h
@@ -75,14 +75,15 @@
 #define HOURS_TENS_MAP   (0x01 << HOURS_TENS)
 
 // Define the activate and deactivate state for the diplay power transistor
+// also define, how the dimming value is calculated
 #ifndef HARDWARE_IPSTUBE_CLOCK
   #define ACTIVATEDISPLAYS      HIGH    // Activate is HIGH for the IPSTUBEs
   #define DEACTIVATEDISPLAYS    LOW     // Deactivate is LOW for the IPSTUBEs
-  #define CALCDIMVALUE(x)       (x)
+  #define CALCDIMVALUE(x)       (x)     // Dimming value is directly used for software dimming
 #else
   #define ACTIVATEDISPLAYS      LOW     // Activate is LOW for the Elekstube
   #define DEACTIVATEDISPLAYS    HIGH    // Deactivate is HIGH for the Elekstube
-  #define CALCDIMVALUE(x)       (255 - x)
+  #define CALCDIMVALUE(x)       (255 - x) // Dimming value is inverted for hardware dimming
 #endif
 
 
@@ -370,8 +371,11 @@
   // #define CSSR_CLOCK_PIN (-1)
   // #define CSSR_LATCH_PIN (-1)
 
-  // The H401 has the enable pin of the LCDs connectected to the VCC, so Always On.  
-  #define TFT_ENABLE_PIN (GPIO_NUM_4) // pin 24 is GPIO4  
+  // All IPSTUBEs has the LCDs pins VCC power (LED Anode) and VDD (Power Supply for Analog) connectected to the VCC (3.3V) and Ground to Ground (PCB), so the displays are Always-On!
+  // EXCEPT: The Q1 transistor is present! 
+  // Then the GPIO4 pin is connected to the transistor and Ground of the LCDs is running through the transistor, so the LCDs can be turned on and off AND dimmed!
+  #define TFT_ENABLE_PIN (GPIO_NUM_4) // pin 24 is GPIO4
+  //if transistor is present and we want hardware dimming, we need to choose a PWM channel for this, can always be defines, even if not used
   #define TFT_PWM_CHANNEL 0
 
   // configure library \TFT_eSPI\User_Setup.h

--- a/EleksTubeHAX_pio/src/Mqtt_client_ips.cpp
+++ b/EleksTubeHAX_pio/src/Mqtt_client_ips.cpp
@@ -349,9 +349,9 @@ void MqttStart() {
     }
       
   #ifndef MQTT_HOME_ASSISTANT
-    char subscibeTopic[100];
-    sprintf(subscibeTopic, "%s/#", MQTT_CLIENT);
-    MQTTclient.subscribe(subscibeTopic);  //Subscribes to all messages send to the device
+    char subscribeTopic[100];
+    sprintf(subscribeTopic, "%s/#", MQTT_CLIENT);
+    MQTTclient.subscribe(subscribeTopic);  //Subscribes to all messages send to the device
 
     sendToBroker("report/online", "true");  // Reports that the device is online
     sendToBroker("report/firmware", FIRMWARE_VERSION);  // Reports the firmware version
@@ -361,27 +361,27 @@ void MqttStart() {
   #endif
 
   #ifdef MQTT_HOME_ASSISTANT
-    char subscibeTopic[100];
-    sprintf(subscibeTopic, "%s/main/set", MQTT_CLIENT);
-    MQTTclient.subscribe(subscibeTopic);
+    char subscribeTopic[100];
+    sprintf(subscribeTopic, "%s/main/set", MQTT_CLIENT);
+    MQTTclient.subscribe(subscribeTopic);
 
-    sprintf(subscibeTopic, "%s/back/set", MQTT_CLIENT);
-    MQTTclient.subscribe(subscibeTopic);
+    sprintf(subscribeTopic, "%s/back/set", MQTT_CLIENT);
+    MQTTclient.subscribe(subscribeTopic);
 
-    sprintf(subscibeTopic, "%s/use_twelve_hours/set", MQTT_CLIENT);
-    MQTTclient.subscribe(subscibeTopic);
+    sprintf(subscribeTopic, "%s/use_twelve_hours/set", MQTT_CLIENT);
+    MQTTclient.subscribe(subscribeTopic);
 
-    sprintf(subscibeTopic, "%s/blank_zero_hours/set", MQTT_CLIENT);
-    MQTTclient.subscribe(subscibeTopic);
+    sprintf(subscribeTopic, "%s/blank_zero_hours/set", MQTT_CLIENT);
+    MQTTclient.subscribe(subscribeTopic);
 
-    sprintf(subscibeTopic, "%s/pulse_bpm/set", MQTT_CLIENT);
-    MQTTclient.subscribe(subscibeTopic);
+    sprintf(subscribeTopic, "%s/pulse_bpm/set", MQTT_CLIENT);
+    MQTTclient.subscribe(subscribeTopic);
 
-    sprintf(subscibeTopic, "%s/breath_bpm/set", MQTT_CLIENT);
-    MQTTclient.subscribe(subscibeTopic);
+    sprintf(subscribeTopic, "%s/breath_bpm/set", MQTT_CLIENT);
+    MQTTclient.subscribe(subscribeTopic);
 
-    sprintf(subscibeTopic, "%s/rainbow_duration/set", MQTT_CLIENT);
-    MQTTclient.subscribe(subscibeTopic);
+    sprintf(subscribeTopic, "%s/rainbow_duration/set", MQTT_CLIENT);
+    MQTTclient.subscribe(subscribeTopic);
   #endif
   }
 #endif
@@ -480,15 +480,15 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
+    if(doc["state"].is<const char*>()) {
       MqttCommandMainPower = doc["state"] == MQTT_STATE_ON;
       MqttCommandMainPowerReceived = true;
     }
-    if(doc.containsKey("brightness")) {
+    if(doc["brightness"].is<int>()) {
        MqttCommandMainBrightness = doc["brightness"];
        MqttCommandMainBrightnessReceived = true;
      }
-    if(doc.containsKey("effect")) {
+    if(doc["effect"].is<const char*>()) {
       MqttCommandMainGraphic = tfts.nameToClockFace(doc["effect"]);   
       MqttCommandMainGraphicReceived = true;
       }
@@ -499,69 +499,74 @@ void callback(char* topic, byte* payload, unsigned int length) {  // A new messa
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
+    if(doc["state"].is<const char*>()) {
       MqttCommandBackPower = doc["state"] == MQTT_STATE_ON;
       MqttCommandBackPowerReceived = true;
     }
-    if(doc.containsKey("brightness")) {
+    if(doc["brightness"].is<int>()) {
       MqttCommandBackBrightness = doc["brightness"];
       MqttCommandBackBrightnessReceived = true;
     }
-    if(doc.containsKey("effect")) {
+    if(doc["effect"].is<const char*>()) {
       strcpy(MqttCommandBackPattern, doc["effect"]);
       MqttCommandBackPatternReceived = true;
-      }
-    if(doc.containsKey("color")) {
+    }
+    if(doc["color"].is<JsonObject>()) {
       MqttCommandBackColorPhase = backlights.hueToPhase(doc["color"]["h"]);   
       MqttCommandBackColorPhaseReceived = true;
-      }
+    }
+
     doc.clear();
   }
   if (strcmp(command[0], "use_twelve_hours") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
+    if(doc["state"].is<const char*>()) {
       MqttCommandUseTwelveHours = doc["state"] == MQTT_STATE_ON;
       MqttCommandUseTwelveHoursReceived = true;
     }
+
     doc.clear();
   }
   if (strcmp(command[0], "blank_zero_hours") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
+    if(doc["state"].is<const char*>()) {
       MqttCommandBlankZeroHours = doc["state"] == MQTT_STATE_ON;
       MqttCommandBlankZeroHoursReceived = true;
     }
+
     doc.clear();
   }
   if (strcmp(command[0], "pulse_bpm") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
+    if(doc["state"].is<int>()) {
       MqttCommandPulseBpm = uint8_t(doc["state"]);
       MqttCommandPulseBpmReceived = true;
     }
+
     doc.clear();
   }
   if (strcmp(command[0], "breath_bpm") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
+    if(doc["state"].is<int>()) {
       MqttCommandBreathBpm = uint8_t(doc["state"]);
       MqttCommandBreathBpmReceived = true;
     }
+
     doc.clear();
   }
   if (strcmp(command[0], "rainbow_duration") == 0 && strcmp(command[1], "set") == 0) {
     JsonDocument doc;
     deserializeJson(doc, payload, length);
     
-    if(doc.containsKey("state")) {
+    if(doc["state"].is<float>()) {
       MqttCommandRainbowSec = float(doc["state"]);
       MqttCommandRainbowSecReceived = true;
     }

--- a/EleksTubeHAX_pio/src/NTPClient_AO.cpp
+++ b/EleksTubeHAX_pio/src/NTPClient_AO.cpp
@@ -92,7 +92,7 @@ bool NTPClient::forceUpdate() {
     return false;
   }
   
-  #ifdef DEBUG_NTPClient
+#ifdef DEBUG_NTPClient
     Serial.print("NTP Data:");
     char s1[4];
     for (int i = 0; i < NTP_PACKET_SIZE; i++) {
@@ -100,7 +100,7 @@ bool NTPClient::forceUpdate() {
       Serial.print(s1);
       }
     Serial.println(".");
-  #endif
+#endif
 
 /*
   unsigned char version = _packetBuffer[0];
@@ -117,34 +117,34 @@ bool NTPClient::forceUpdate() {
 	//Perform a few validity checks on the packet
 	if((_packetBuffer[0] & 0b11000000) == 0b11000000)		//Check for LI=UNSYNC
     {
-    #ifdef DEBUG_NTPClient
+#ifdef DEBUG_NTPClient
       Serial.println("err: NTP UnSync");
-    #endif
-    return false;
+#endif
+      return false;
     }
   
 	if((_packetBuffer[0] & 0b00111000) >> 3 < 0b100)		//Check for Version >= 4
     {
-    #ifdef DEBUG_NTPClient
+#ifdef DEBUG_NTPClient
       Serial.println("err: Incorrect NTP Version");
-    #endif
-    return false;
+#endif
+      return false;
     }
 
 	if((_packetBuffer[0] & 0b00000111) != 0b100)			//Check for Mode == Server
     {
-    #ifdef DEBUG_NTPClient
+#ifdef DEBUG_NTPClient
       Serial.println("err: NTP mode is not Server");
-    #endif
-    return false;
+#endif
+      return false;
     }
 
 	if((_packetBuffer[1] < 1) || (_packetBuffer[1] > 15))		//Check for valid Stratum
     {
-    #ifdef DEBUG_NTPClient
+#ifdef DEBUG_NTPClient
       Serial.println("err: Incorrect NTP Stratum");
-    #endif
-    return false;
+#endif
+      return false;
     }
 
 	if(	_packetBuffer[16] == 0 && _packetBuffer[17] == 0 && 
@@ -152,10 +152,10 @@ bool NTPClient::forceUpdate() {
 		_packetBuffer[20] == 0 && _packetBuffer[21] == 0 &&
 		_packetBuffer[22] == 0 && _packetBuffer[22] == 0)		//Check for ReferenceTimestamp != 0
     {
-    #ifdef DEBUG_NTPClient
+#ifdef DEBUG_NTPClient
       Serial.println("err: Incorrect NTP Ref Timestamp");
-    #endif
-    return false;
+#endif
+      return false;
     }
 
   

--- a/EleksTubeHAX_pio/src/TFTs.cpp
+++ b/EleksTubeHAX_pio/src/TFTs.cpp
@@ -35,6 +35,7 @@ void TFTs::begin() {
 }
 
 void TFTs::reinit() {
+  #ifndef TFT_SKIP_REINIT
   // Start with all displays selected.
   chip_select.begin();
   chip_select.setAll();
@@ -50,6 +51,9 @@ void TFTs::reinit() {
 
   // Initialize the super class.
   init();
+  #else
+  enableAllDisplays();
+  #endif
 }
 
 void TFTs::clear() {

--- a/EleksTubeHAX_pio/src/TFTs.cpp
+++ b/EleksTubeHAX_pio/src/TFTs.cpp
@@ -10,6 +10,11 @@ void TFTs::begin() {
 
   // Turn power on to displays. 
   pinMode(TFT_ENABLE_PIN, OUTPUT);
+  #ifdef DIM_WITH_ENABLE_PIN_PWM
+  ledcAttachPin(TFT_ENABLE_PIN, TFT_PWM_CHANNEL);
+  ledcChangeFrequency(TFT_PWM_CHANNEL, 20000, 8);
+  ProcessUpdatedDimming();
+  #endif
   enableAllDisplays();
   InvalidateImageInBuffer();
 
@@ -36,6 +41,11 @@ void TFTs::reinit() {
 
   // Turn power on to displays.
   pinMode(TFT_ENABLE_PIN, OUTPUT);
+  #ifdef DIM_WITH_ENABLE_PIN_PWM
+  ledcAttachPin(TFT_ENABLE_PIN, TFT_PWM_CHANNEL);
+  ledcChangeFrequency(TFT_PWM_CHANNEL, 20000, 8);
+  ProcessUpdatedDimming();
+  #endif
   enableAllDisplays();
 
   // Initialize the super class.
@@ -83,15 +93,23 @@ void TFTs::showNoMqttStatus() {
 }
 
 void TFTs::enableAllDisplays() {
-  // Turn power on to displays.
-  digitalWrite(TFT_ENABLE_PIN, ACTIVATEDISPLAYS);
+  // Turn power on to displays.  
   enabled = true;
+  #ifndef DIM_WITH_ENABLE_PIN_PWM
+  digitalWrite(TFT_ENABLE_PIN, ACTIVATEDISPLAYS);
+  #else
+  ProcessUpdatedDimming();
+  #endif
 }
 
 void TFTs::disableAllDisplays() {
   // Turn power off to displays.
-  digitalWrite(TFT_ENABLE_PIN, DEACTIVATEDISPLAYS);
   enabled = false;
+  #ifndef DIM_WITH_ENABLE_PIN_PWM
+  digitalWrite(TFT_ENABLE_PIN, DEACTIVATEDISPLAYS);
+  #else
+  ProcessUpdatedDimming();
+  #endif
 }
 
 void TFTs::toggleAllDisplays() {
@@ -177,6 +195,18 @@ void TFTs::LoadNextImage() {
 
 void TFTs::InvalidateImageInBuffer() { // force reload from Flash with new dimming settings
   FileInBuffer=255; // invalid, always load first image
+}
+
+void TFTs::ProcessUpdatedDimming() {
+  #ifdef DIM_WITH_ENABLE_PIN_PWM
+  if (enabled) {
+    ledcWrite(TFT_PWM_CHANNEL, CALCDIMVALUE(dimming));
+  } else {
+    ledcWrite(TFT_PWM_CHANNEL, CALCDIMVALUE(0));
+  }
+  #else
+  InvalidateImageInBuffer();
+  #endif
 }
 
 bool TFTs::FileExists(const char* path) {
@@ -336,9 +366,11 @@ bool TFTs::LoadImageIntoBuffer(uint8_t file_index) {
         }
 
         uint16_t color = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | ((b & 0xFF) >> 3);
+        #ifndef DIM_WITH_ENABLE_PIN_PWM
         if (dimming < 255) { // only dim when needed
           color = alphaBlend(dimming, color, TFT_BLACK);
         } // dimming
+        #endif
 
         UnpackedImageBuffer[row+y][col+x] = color;
     } // col
@@ -447,6 +479,9 @@ bool TFTs::LoadImageIntoBuffer(uint8_t file_index) {
     
     // Colors are already in 16-bit R5, G6, B5 format
     for (col = 0; col < w; col++) {
+      #ifdef DIM_WITH_ENABLE_PIN_PWM
+      UnpackedImageBuffer[row+y][col+x] = (lineBuffer[col*2+1] << 8) | (lineBuffer[col*2]);
+      #else
       if (dimming == 255) { // not needed, copy directly
         UnpackedImageBuffer[row+y][col+x] = (lineBuffer[col*2+1] << 8) | (lineBuffer[col*2]);
       } else {
@@ -465,6 +500,7 @@ bool TFTs::LoadImageIntoBuffer(uint8_t file_index) {
         b = b >> 8;
         UnpackedImageBuffer[row+y][col+x] = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
       } // dimming
+      #endif
     } // col
   } // row
   FileInBuffer = file_index;

--- a/EleksTubeHAX_pio/src/TFTs.h
+++ b/EleksTubeHAX_pio/src/TFTs.h
@@ -55,6 +55,7 @@ public:
   uint8_t NumberOfClockFaces = 0;
   void LoadNextImage();
   void InvalidateImageInBuffer(); // force reload from Flash with new dimming settings
+  void ProcessUpdatedDimming();
 
   String clockFaceToName(uint8_t clockFace);
   uint8_t nameToClockFace(String name);

--- a/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
+++ b/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
@@ -34,13 +34,25 @@
 #define TFT_DIMMED_INTENSITY        20  // 0..255
 
 #ifdef HARDWARE_IPSTUBE_CLOCK
-  // comment the next line out, to disable hardware dimming with GPIO4 pin (TFT_ENABLE_PIN) for IPSTUBE clock
-  // (in case you have a clock that does not support hardware dimming because of missing Q1 transistor)
+  // Skip reinitialization
+  // Always skip reinitialization for IPSTUBE clocks, because the displays are either always on (versions without Q1 transistor) 
+  // and a reinit just shows strange patterns on the displays and forces an unnecessary redraw of the clock digits.
+  // or seems to don't need a reinit (with Q1) -> this is an assumption, because the display came back on after a few hours without problems
+  // NOTE: If this causes wake up issues for you, disable it by commenting the following line out and go back to full reinit after display power off
+  #define TFT_SKIP_REINIT
+
+  // Hardware dimming!
+  // This feature is only supported by IPSTUBE clocks by now!!!
+  // DON'T USE IT WITH OTHER CLOCKS! IT MAY DAMAGE YOUR CLOCK!
+
+  // In case you have an IPSTUBE clock that does not support hardware dimming because of missing Q1 transistor:
+  // This will NOT damage your clock, but the dimming of the displays will be totally disabled! Also the LCD power switch will not work!
+  // If you notice, that the night time dimming or manual dimming does not work, you may have a clock without the Q1 transistor 
+  // and you can/should comment the following line out to get back to the software dimming!
+
+  // Comment the next line out, to DISABLE hardware dimming with GPIO4 pin (TFT_ENABLE_PIN) for a IPSTUBE clock  
   #define DIM_WITH_ENABLE_PIN_PWM
-  // it is recommended to try this feature only if you are sure that your clock supports hardware dimming
-  // (that is, it is available in native application and really dims the backlight) because it may damage clock
-  // if used with unsupported hardware! this feature only is expected to be supported safely by IPSTUBE clocks by now
-  
+    
   //NOTE: If NIGTHTIME_DIMMING is enabled: 
   // For the main LCDs: The dimming will be set to the hard coded value TFT_DIMMED_INTENSITY in the given time period EVERY HOUR beginning at NIGHT_TIME
   //    and will set back to the maximum brightness at DAY_TIME...Disable NIGHTTIME_DIMMING if you want to use the manual set dimming value all the time
@@ -49,12 +61,10 @@
 
   // TODO: Store the dimming values and dimming times in the NVS partition to keep the last dimming value and not use the hard coded values
   // make the times and values adjustable in the menu and/or via MQTT for both main and backlight dimming
-#endif
 
-#ifdef DIM_WITH_ENABLE_PIN_PWM
-  // skip reinitialization if using PWM to control backlight since actual TFTs are never deactivated
-  // disable by commenting the following line if this causes wake up issues from disabled (brightness 0) state
-  #define TFT_SKIP_REINIT
+  // TODO: Save the values changed via MQTT/in HA in the NVS partition to keep the values after a reboot. Maybe define a "save command" in HA or trigger after 
+  // a few minutes of inactivity only if changed something or in the "free time" of the loop cycle...
+  // Save it every time receiving MQTT commands is a BAD idea, we know that already ;)
 #endif
 
 // ************* WiFi config *************

--- a/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
+++ b/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
@@ -33,39 +33,6 @@
 #define BACKLIGHT_DIMMED_INTENSITY  1   // 0..7
 #define TFT_DIMMED_INTENSITY        20  // 0..255
 
-#ifdef HARDWARE_IPSTUBE_CLOCK
-  // Skip reinitialization
-  // Always skip reinitialization for IPSTUBE clocks, because the displays are either always on (versions without Q1 transistor) 
-  // and a reinit just shows strange patterns on the displays and forces an unnecessary redraw of the clock digits.
-  // or seems to don't need a reinit (with Q1) -> this is an assumption, because the display came back on after a few hours without problems
-  // NOTE: If this causes wake up issues for you, disable it by commenting the following line out and go back to full reinit after display power off
-  #define TFT_SKIP_REINIT
-
-  // Hardware dimming!
-  // This feature is only supported by IPSTUBE clocks by now!!!
-  // DON'T USE IT WITH OTHER CLOCKS! IT MAY DAMAGE YOUR CLOCK!
-
-  // In case you have an IPSTUBE clock that does not support hardware dimming because of missing Q1 transistor:
-  // This will NOT damage your clock, but the dimming of the displays will be totally disabled! Also the LCD power switch will not work!
-  // If you notice, that the night time dimming or manual dimming does not work, you may have a clock without the Q1 transistor 
-  // and you can/should comment the following line out to get back to the software dimming!
-
-  // Comment the next line out, to DISABLE hardware dimming with GPIO4 pin (TFT_ENABLE_PIN) for a IPSTUBE clock  
-  #define DIM_WITH_ENABLE_PIN_PWM
-    
-  //NOTE: If NIGTHTIME_DIMMING is enabled: 
-  // For the main LCDs: The dimming will be set to the hard coded value TFT_DIMMED_INTENSITY in the given time period EVERY HOUR beginning at NIGHT_TIME
-  //    and will set back to the maximum brightness at DAY_TIME...Disable NIGHTTIME_DIMMING if you want to use the manual set dimming value all the time
-  // For the backlight dimming: The dimming will ALWAYS stay to the hard coded value BACKLIGHT_DIMMED_INTENSITY in the given night time period! 
-  //    The check for it is done and the value is apply every loop...Disable NIGHTTIME_DIMMING if you want to use the manual set dimming value all the time
-
-  // TODO: Store the dimming values and dimming times in the NVS partition to keep the last dimming value and not use the hard coded values
-  // make the times and values adjustable in the menu and/or via MQTT for both main and backlight dimming
-
-  // TODO: Save the values changed via MQTT/in HA in the NVS partition to keep the values after a reboot. Maybe define a "save command" in HA or trigger after 
-  // a few minutes of inactivity only if changed something or in the "free time" of the loop cycle...
-  // Save it every time receiving MQTT commands is a BAD idea, we know that already ;)
-#endif
 
 // ************* WiFi config *************
 #define WIFI_CONNECT_TIMEOUT_SEC    20

--- a/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
+++ b/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
@@ -27,19 +27,28 @@
 
 
 // ************* Display Dimming / Night time operation *************
-#define DIMMING                         // uncomment to enable hardware dimming
+#define NIGHTTIME_DIMMING               // uncomment to enable dimming in the given time period between NIGHT_TIME and DAY_TIME
 #define NIGHT_TIME                  22  // dim displays at 10 pm 
 #define DAY_TIME                    7   // full brightness after 7 am
 #define BACKLIGHT_DIMMED_INTENSITY  1   // 0..7
 #define TFT_DIMMED_INTENSITY        20  // 0..255
 
 #ifdef HARDWARE_IPSTUBE_CLOCK
-  // comment the next line out to disable hardware dimming with GPIO4 pin (TFT_ENABLE_PIN) for IPSTUBE clock
+  // comment the next line out, to disable hardware dimming with GPIO4 pin (TFT_ENABLE_PIN) for IPSTUBE clock
   // (in case you have a clock that does not support hardware dimming because of missing Q1 transistor)
   #define DIM_WITH_ENABLE_PIN_PWM
   // it is recommended to try this feature only if you are sure that your clock supports hardware dimming
   // (that is, it is available in native application and really dims the backlight) because it may damage clock
   // if used with unsupported hardware! this feature only is expected to be supported safely by IPSTUBE clocks by now
+  
+  //NOTE: If NIGTHTIME_DIMMING is enabled: 
+  // For the main LCDs: The dimming will be set to the hard coded value TFT_DIMMED_INTENSITY in the given time period EVERY HOUR beginning at NIGHT_TIME
+  //    and will set back to the maximum brightness at DAY_TIME...Disable NIGHTTIME_DIMMING if you want to use the manual set dimming value all the time
+  // For the backlight dimming: The dimming will ALWAYS stay to the hard coded value BACKLIGHT_DIMMED_INTENSITY in the given night time period! 
+  //    The check for it is done and the value is apply every loop...Disable NIGHTTIME_DIMMING if you want to use the manual set dimming value all the time
+
+  // TODO: Store the dimming values and dimming times in the NVS partition to keep the last dimming value and not use the hard coded values
+  // make the times and values adjustable in the menu and/or via MQTT for both main and backlight dimming
 #endif
 
 #ifdef DIM_WITH_ENABLE_PIN_PWM

--- a/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
+++ b/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
@@ -32,8 +32,15 @@
 #define DAY_TIME                    7   // full brightness after 7 am
 #define BACKLIGHT_DIMMED_INTENSITY  1   // 0..7
 #define TFT_DIMMED_INTENSITY        20  // 0..255
-//#define DIM_WITH_ENABLE_PIN_PWM         // uncomment to enable hardware dimming with TFT Enable pin (GPIO 4)
 
+#ifdef HARDWARE_IPSTUBE_CLOCK
+  // comment the next line out to disable hardware dimming with GPIO4 pin (TFT_ENABLE_PIN) for IPSTUBE clock
+  // (in case you have a clock that does not support hardware dimming because of missing Q1 transistor)
+  #define DIM_WITH_ENABLE_PIN_PWM
+  // it is recommended to try this feature only if you are sure that your clock supports hardware dimming
+  // (that is, it is available in native application and really dims the backlight) because it may damage clock
+  // if used with unsupported hardware! this feature only is expected to be supported safely by IPSTUBE clocks by now
+#endif
 
 // ************* WiFi config *************
 #define WIFI_CONNECT_TIMEOUT_SEC    20

--- a/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
+++ b/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
@@ -32,6 +32,7 @@
 #define DAY_TIME                    7   // full brightness after 7 am
 #define BACKLIGHT_DIMMED_INTENSITY  1   // 0..7
 #define TFT_DIMMED_INTENSITY        20  // 0..255
+//#define DIM_WITH_ENABLE_PIN_PWM         // uncomment to enable hardware dimming with TFT Enable pin (GPIO 4)
 
 
 // ************* WiFi config *************

--- a/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
+++ b/EleksTubeHAX_pio/src/_USER_DEFINES - empty.h
@@ -42,6 +42,12 @@
   // if used with unsupported hardware! this feature only is expected to be supported safely by IPSTUBE clocks by now
 #endif
 
+#ifdef DIM_WITH_ENABLE_PIN_PWM
+  // skip reinitialization if using PWM to control backlight since actual TFTs are never deactivated
+  // disable by commenting the following line if this causes wake up issues from disabled (brightness 0) state
+  #define TFT_SKIP_REINIT
+#endif
+
 // ************* WiFi config *************
 #define WIFI_CONNECT_TIMEOUT_SEC    20
 #define WIFI_RETRY_CONNECTION_SEC   15

--- a/EleksTubeHAX_pio/src/main.cpp
+++ b/EleksTubeHAX_pio/src/main.cpp
@@ -239,7 +239,7 @@ void loop() {
   }
 
   if(MqttCommandBackBrightnessReceived) {
-    MqttCommandBackBrightnessReceived = false;   
+    MqttCommandBackBrightnessReceived = false;
     backlights.setIntensity(uint8_t(MqttCommandBackBrightness));
   }
 
@@ -674,13 +674,13 @@ bool isNightTime(uint8_t current_hour) {
     }
     else {
       // "Night" starts after midnight, entirely contained within the day
-      return (current_hour >= NIGHT_TIME) && (current_hour < DAY_TIME);  
+      return (current_hour >= NIGHT_TIME) && (current_hour < DAY_TIME);
     }
 }
 
 void EveryFullHour(bool loopUpdate) {
-  // dim the clock at night
-  #ifdef DIMMING
+  // dim the clock in the night
+#ifdef NIGHTTIME_DIMMING
   uint8_t current_hour = uclock.getHour24();
   FullHour = current_hour != hour_old;
   if (FullHour) {
@@ -690,22 +690,22 @@ void EveryFullHour(bool loopUpdate) {
       Serial.println("Setting night mode (dimmed)");
       tfts.dimming = TFT_DIMMED_INTENSITY;
       tfts.ProcessUpdatedDimming();
-      backlights.dimming = true;
+      backlights.setDimming(true);
       if (menu.getState() == Menu::idle || !loopUpdate) { // otherwise erases the menu
         updateClockDisplay(TFTs::force); // update all
       }
     } else {
-      Serial.println("Setting daytime mode (normal brightness)");
+      Serial.println("Setting daytime mode (max brightness)");
       tfts.dimming = 255; // 0..255
       tfts.ProcessUpdatedDimming();
-      backlights.dimming = false;
+      backlights.setDimming(false);
       if (menu.getState() == Menu::idle || !loopUpdate) { // otherwise erases the menu
         updateClockDisplay(TFTs::force); // update all
       }
     }
     hour_old = current_hour;
   }
-  #endif   
+#endif   
 }
 
 void UpdateDstEveryNight() {

--- a/EleksTubeHAX_pio/src/main.cpp
+++ b/EleksTubeHAX_pio/src/main.cpp
@@ -234,7 +234,7 @@ void loop() {
   if(MqttCommandMainBrightnessReceived) {
     MqttCommandMainBrightnessReceived = false;
     tfts.dimming = MqttCommandMainBrightness;
-    tfts.InvalidateImageInBuffer();
+    tfts.ProcessUpdatedDimming();
     updateClockDisplay(TFTs::force);
   }
 
@@ -689,7 +689,7 @@ void EveryFullHour(bool loopUpdate) {
     if (isNightTime(current_hour)) {
       Serial.println("Setting night mode (dimmed)");
       tfts.dimming = TFT_DIMMED_INTENSITY;
-      tfts.InvalidateImageInBuffer(); // invalidate; reload images with new dimming value
+      tfts.ProcessUpdatedDimming();
       backlights.dimming = true;
       if (menu.getState() == Menu::idle || !loopUpdate) { // otherwise erases the menu
         updateClockDisplay(TFTs::force); // update all
@@ -697,7 +697,7 @@ void EveryFullHour(bool loopUpdate) {
     } else {
       Serial.println("Setting daytime mode (normal brightness)");
       tfts.dimming = 255; // 0..255
-      tfts.InvalidateImageInBuffer(); // invalidate; reload images with new dimming value
+      tfts.ProcessUpdatedDimming();
       backlights.dimming = false;
       if (menu.getState() == Menu::idle || !loopUpdate) { // otherwise erases the menu
         updateClockDisplay(TFTs::force); // update all


### PR DESCRIPTION
This PR adds an additional **optional** capability (`DIM_WITH_ENABLE_PIN_PWM`) to dim the displays by PWMing `TFT_ENABLE_PIN` instead of blending images with black color.

When supported by the clock, it allows for much quicker dimming value changes (instantaneous, there is no need to redraw all images) and much better dark colors at night (without brighted out blacks and parasitic illumination).

The only possible drawbacks, are that the clock may not support such feature (most likely it is supported if the original firmware and application allows dimming, and the display itself actually gets dimmer), and that the dimming scale is really not linear (the effect is much more visible on lower brightness levels - it may even feasible to increase resolution of duty cycle and remap linear to logarithmic values for better brightness control).